### PR TITLE
Add power ups to avatar card

### DIFF
--- a/milabowl-astro/src/assets/icon_bomb.svg
+++ b/milabowl-astro/src/assets/icon_bomb.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="74.695053"
+   height="79.856613"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.1 r9760"
+   sodipodi:docname="Neues Dokument 1">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3915">
+      <stop
+         style="stop-color:#b43600;stop-opacity:1;"
+         offset="0"
+         id="stop3917" />
+      <stop
+         style="stop-color:#ffdb40;stop-opacity:1;"
+         offset="1"
+         id="stop3919" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3755">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.1864595;"
+         offset="0"
+         id="stop3757" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop3759" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3755"
+       id="radialGradient4199"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70573312,-0.43714663,0.40463268,0.65324231,-115.20784,282.58588)"
+       cx="252.45213"
+       cy="422.71432"
+       fx="252.45213"
+       fy="422.71432"
+       r="60.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3755"
+       id="radialGradient4201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70573312,-0.43714663,0.40463268,0.65324231,-115.20784,282.58588)"
+       cx="252.45213"
+       cy="422.71432"
+       fx="252.45213"
+       fy="422.71432"
+       r="60.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3755"
+       id="radialGradient4245"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70573312,-0.43714663,0.40463268,0.65324231,-115.20784,282.58588)"
+       cx="252.45213"
+       cy="422.71432"
+       fx="252.45213"
+       fy="422.71432"
+       r="60.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3755"
+       id="radialGradient4247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70573312,-0.43714663,0.40463268,0.65324231,-115.20784,282.58588)"
+       cx="252.45213"
+       cy="422.71432"
+       fx="252.45213"
+       fy="422.71432"
+       r="60.5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="63.294717"
+     inkscape:cy="61.249319"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1600"
+     inkscape:window-height="867"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-402.91703,-532.35838)">
+    <g
+       id="g4235">
+      <g
+         transform="matrix(0.39752001,0,0,0.39752001,242.74945,368.84728)"
+         id="g3831">
+        <path
+           d="m 331,478.36218 c 0,33.13709 -26.86292,60 -60,60 -33.13708,0 -60,-26.86291 -60,-60 0,-33.13708 26.86292,-60 60,-60 33.13708,0 60,26.86292 60,60 z"
+           sodipodi:ry="60"
+           sodipodi:rx="60"
+           sodipodi:cy="478.36218"
+           sodipodi:cx="271"
+           id="path3765"
+           style="color:#000000;fill:url(#radialGradient4245);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           sodipodi:type="arc"
+           transform="matrix(0.99978306,-0.02082881,0.02082881,0.99978306,182.09507,78.748386)" />
+        <path
+           sodipodi:type="arc"
+           style="opacity:0.84039085;color:#000000;fill:url(#radialGradient4247);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           id="path2985"
+           sodipodi:cx="271"
+           sodipodi:cy="478.36218"
+           sodipodi:rx="60"
+           sodipodi:ry="60"
+           d="m 331,478.36218 c 0,33.13709 -26.86292,60 -60,60 -33.13708,0 -60,-26.86291 -60,-60 0,-33.13708 26.86292,-60 60,-60 33.13708,0 60,26.86292 60,60 z"
+           transform="matrix(0.99614858,0.08768134,-0.08768134,0.99614858,234.90786,51.929886)"
+           inkscape:transform-center-x="-4.4206828"
+           inkscape:transform-center-y="-11.150847" />
+      </g>
+      <path
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0"
+         id="path3835"
+         d="m 456.82411,552.65201 c -1.16069,3.43662 -4.85488,1.14587 -5.65661,5.03618 -0.35684,1.73148 -2.00279,2.34731 -2.00279,2.34731"
+         style="fill:none;stroke:#5a5a5a;stroke-width:2.11899996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <rect
+         transform="matrix(0.79908813,0.60121391,-0.62085572,0.78392485,0,0)"
+         ry="0"
+         y="176.71242"
+         x="696.43011"
+         height="19.47333"
+         width="7.3525105"
+         id="rect3801"
+         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         transform="matrix(0.18407185,-0.25490818,-0.23824201,-0.22692275,469.19274,772.86649)"
+         d="m 472,394.36218 16.35404,-0.008 4.30621,-15.77692 8.18369,14.15917 15.81631,-4.15917 -8.17035,14.16686 11.5101,11.61775 -16.35404,0.008 -4.30621,15.77691 -8.18369,-14.15916 -15.81631,4.15916 8.17035,-14.16686 z"
+         inkscape:randomized="0"
+         inkscape:rounded="-3.469447e-18"
+         inkscape:flatsided="false"
+         sodipodi:arg2="-2.2232027"
+         sodipodi:arg1="-2.7468015"
+         sodipodi:r2="12.594234"
+         sodipodi:r1="26"
+         sodipodi:cy="404.36218"
+         sodipodi:cx="496"
+         sodipodi:sides="6"
+         id="path4177"
+         style="color:#000000;fill:#f75900;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5999999;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="star" />
+      <path
+         transform="matrix(0.08308782,-0.2132348,-0.17581866,-0.09961833,503.0031,691.43645)"
+         d="m 472,394.36218 16.35404,-0.008 4.30621,-15.77692 8.18369,14.15917 15.81631,-4.15917 -8.17035,14.16686 11.5101,11.61775 -16.35404,0.008 -4.30621,15.77691 -8.18369,-14.15916 -15.81631,4.15916 8.17035,-14.16686 z"
+         inkscape:randomized="0"
+         inkscape:rounded="-3.469447e-18"
+         inkscape:flatsided="false"
+         sodipodi:arg2="-2.2232027"
+         sodipodi:arg1="-2.7468015"
+         sodipodi:r2="12.594234"
+         sodipodi:r1="26"
+         sodipodi:cy="404.36218"
+         sodipodi:cx="496"
+         sodipodi:sides="6"
+         id="path4181"
+         style="color:#000000;fill:#f78000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5999999;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="star" />
+      <path
+         transform="matrix(0.10520766,-0.23875554,-0.22357917,-0.11191261,486.06697,702.88361)"
+         d="m 472,394.36218 16.35404,-0.008 4.30621,-15.77692 8.18369,14.15917 15.81631,-4.15917 -8.17035,14.16686 11.5101,11.61775 -16.35404,0.008 -4.30621,15.77691 -8.18369,-14.15916 -15.81631,4.15916 8.17035,-14.16686 z"
+         inkscape:randomized="0"
+         inkscape:rounded="-3.469447e-18"
+         inkscape:flatsided="false"
+         sodipodi:arg2="-2.2232027"
+         sodipodi:arg1="-2.7468015"
+         sodipodi:r2="12.594234"
+         sodipodi:r1="26"
+         sodipodi:cy="404.36218"
+         sodipodi:cx="496"
+         sodipodi:sides="6"
+         id="path4183"
+         style="color:#000000;fill:#f7a200;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5999999;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="star" />
+    </g>
+  </g>
+</svg>

--- a/milabowl-astro/src/components/core/Avatar.tsx
+++ b/milabowl-astro/src/components/core/Avatar.tsx
@@ -1,5 +1,10 @@
 import styles from "./Avatar.module.css";
 import party from "party-js";
+import PowerUp from "./PowerUp"
+import game_state from "../../game_state/game_state.json";
+import type { ResultsByUser, GameWeekResult } from "../../game_state/gameState";
+
+const milaResultsByUser: ResultsByUser = game_state.resultsByUser;
 
 export interface AvatarProps {
     teamName: string;
@@ -97,9 +102,34 @@ const Avatar: React.FC<AvatarProps> = ({ children, teamName }) => {
     if (teamName in userProfileDict) {
         user = userProfileDict[teamName];
     }
+
+    // List of existing power ups
+    let powerUpGWs = {
+        "3xc": "",
+        "wildcard": "",
+        "freehit": "",
+        "bboost": "",
+    };
+    // For each power up, determine if (and when) it has been used by the current player
+    const userResults: GameWeekResult[] = milaResultsByUser.find(e => e.teamName == teamName).results;
+
+    for (const [key, value] of Object.entries(powerUpGWs)) {
+        let gw = userResults.find(e => e.milaPoints.activeChip == key)?.gameWeek;
+        powerUpGWs[key] = gw;
+    }
+
+    if (teamName.includes("Start")) {
+        powerUpGWs = {
+            "3xc": "",
+            "wildcard": "",
+            "freehit": "",
+            "bboost": "",
+        };
+    }
+
     return (
         <div className={styles.avatarDiv}>
-            <div data-popover-target={"popover-user-profile" + teamName.replaceAll(" ", "")} className={styles.avatar + " w-6 md:w-7 lg:w-9"}> 
+            <div data-popover-target={"popover-user-profile" + teamName.replaceAll(" ", "")} className={styles.avatar + " w-6 md:w-7 lg:w-9"}>
                 {children}
             </div>
             {/* <img
@@ -109,13 +139,13 @@ const Avatar: React.FC<AvatarProps> = ({ children, teamName }) => {
                 //width={size}
                 data-popover-target={"popover-user-profile" + teamName.replaceAll(" ", "")}
             /> */}
-            <div data-popover id={"popover-user-profile" + teamName.replaceAll(" ", "")} role="tooltip" className="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:bg-gray-800 dark:border-gray-600">
+            <div data-popover id={"popover-user-profile" + teamName.replaceAll(" ", "")} role="tooltip" className="absolute z-10 invisible inline-block w-81 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:bg-gray-800 dark:border-gray-600">
                 <div className="p-3">
                     <div className="flex items-center justify-between mb-2">
                         {/* <a href="#">
                             <img className="w-24 h-24 rounded-full" src={user["avatarSrc"]} alt="Avatar pic" />
                         </a> */}
-                         <div className={styles.avatar + " w-24 h-24 rounded-full"}> 
+                        <div className={styles.avatar + " w-24 h-24 rounded-full"}>
                             {children}
                         </div>
                         <div>
@@ -133,7 +163,26 @@ const Avatar: React.FC<AvatarProps> = ({ children, teamName }) => {
                         <a href="#" className="hover:underline">@{user.name}</a>
                     </p>
                     <p className="mb-4 text-sm">{user.info}</p>
+
+                    <div className="text-white pb-1"> Power ups: (played in gw)
+                    </div>
                     <ul className="flex text-sm">
+                        <li>
+                            <PowerUp type="3xc" gwPlayed={powerUpGWs["3xc"]}></PowerUp>
+                        </li>
+                        <li>
+                            <PowerUp type="wildcard" gwPlayed={powerUpGWs["wildcard"]}></PowerUp>
+                        </li>
+                        <li>
+                            <PowerUp type="freehit" gwPlayed={powerUpGWs["freehit"]}></PowerUp>
+                        </li>
+                        <li>
+                            <PowerUp type="bboost" gwPlayed={powerUpGWs["bboost"]}></PowerUp>
+                        </li>
+                    </ul>
+
+
+                    <ul className="flex text-sm pt-2">
                         <li className="mr-2">
                             <a href="#" className="hover:underline">
                                 <span className="font-semibold text-gray-900 dark:text-white">{user.following} </span>

--- a/milabowl-astro/src/components/core/Avatar.tsx
+++ b/milabowl-astro/src/components/core/Avatar.tsx
@@ -41,8 +41,8 @@ const userProfileDict: UserProfiles = {
     },
     "Haalandaise Saus": {
         "info": "Mila try-hard",
-        "followers": 0,
-        "following": 0,
+        "followers": 1,
+        "following": 1,
         "name": "eivind",
         "avatarSrc": imageRoot + "eivind.png"
     },
@@ -168,16 +168,16 @@ const Avatar: React.FC<AvatarProps> = ({ children, teamName }) => {
                     </div>
                     <ul className="flex text-sm">
                         <li>
-                            <PowerUp type="3xc" gwPlayed={powerUpGWs["3xc"]}></PowerUp>
+                            <PowerUp type="3xc" playerName={user.name.replaceAll(" ", "")} gwPlayed={powerUpGWs["3xc"]} />
                         </li>
                         <li>
-                            <PowerUp type="wildcard" gwPlayed={powerUpGWs["wildcard"]}></PowerUp>
+                            <PowerUp type="wildcard" playerName={user.name.replaceAll(" ", "")} gwPlayed={powerUpGWs["wildcard"]} />
                         </li>
                         <li>
-                            <PowerUp type="freehit" gwPlayed={powerUpGWs["freehit"]}></PowerUp>
+                            <PowerUp type="freehit" playerName={user.name.replaceAll(" ", "")} gwPlayed={powerUpGWs["freehit"]} />
                         </li>
                         <li>
-                            <PowerUp type="bboost" gwPlayed={powerUpGWs["bboost"]}></PowerUp>
+                            <PowerUp type="bboost" playerName={user.name.replaceAll(" ", "")} gwPlayed={powerUpGWs["bboost"]} />
                         </li>
                     </ul>
 

--- a/milabowl-astro/src/components/core/AvatarProvider.astro
+++ b/milabowl-astro/src/components/core/AvatarProvider.astro
@@ -16,7 +16,7 @@ const images: ImageMetadata[] = await Astro.glob("../../assets/*").then(
 
 <!-- <Image style="border-radius: 999px" src={images.find(i => userName.toLowerCase().replaceAll(" ", "_").includes(i.src.toLowerCase().split('.')[0].split('/').pop()!.replace(".png", "")))!} alt={`Avatar for ${userName}`}> </Image>-->
 <Image
-  style="border-radius: 999px"
+  style="border-radius: 999px; display:inline"
   src={images.find((i) =>
     i.src.includes(userName.toLowerCase().replaceAll(" ", "_"))
   )!}

--- a/milabowl-astro/src/components/core/AvatarProvider.astro
+++ b/milabowl-astro/src/components/core/AvatarProvider.astro
@@ -1,15 +1,24 @@
 ---
-import { Image } from "astro:assets"
+import { Image } from "astro:assets";
 
 export interface Props {
-    userName: string;
+  userName: string;
 }
 
 const { userName } = Astro.props;
 
-const images : ImageMetadata[] = await Astro.glob("../../assets/*").then(files => {
-  return files.map(file => file.default);
-});
-
+const images: ImageMetadata[] = await Astro.glob("../../assets/*").then(
+  (files) => {
+    return files.map((file) => file.default);
+  }
+);
 ---
-<Image style="border-radius: 999px" src={images.find(i => userName.toLowerCase().replaceAll(" ", "_").includes(i.src.toLowerCase().split('.')[0].split('/').pop()!.replace(".png", "")))!} alt={`Avatar for ${userName}`}> </Image>
+
+<!-- <Image style="border-radius: 999px" src={images.find(i => userName.toLowerCase().replaceAll(" ", "_").includes(i.src.toLowerCase().split('.')[0].split('/').pop()!.replace(".png", "")))!} alt={`Avatar for ${userName}`}> </Image>-->
+<Image
+  style="border-radius: 999px"
+  src={images.find((i) =>
+    i.src.includes(userName.toLowerCase().replaceAll(" ", "_"))
+  )!}
+  alt={`Avatar for ${userName}`}
+/>

--- a/milabowl-astro/src/components/core/PowerUp.tsx
+++ b/milabowl-astro/src/components/core/PowerUp.tsx
@@ -1,0 +1,84 @@
+import iconBomb from "./../../assets/icon_bomb.svg";
+import React, { useState } from "react";
+
+export interface PowerUpProps {
+    type: string;  // One of 3xc, wildcard, freehit, bboost
+    gwPlayed?: string | null; // Make this nullable?
+}
+
+interface iTypeToColor {
+    [key: string]: string;
+}
+
+const typeToColor: iTypeToColor = {
+    "3xc": "purple",
+    "wildcard": "yellow",
+    "freehit": "green",
+    "bboost": "red"
+};
+
+const icon_envelope =
+    <svg className="relative w-3 h-3 z-10" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 16">
+        <path d="m10.036 8.278 9.258-7.79A1.979 1.979 0 0 0 18 0H2A1.987 1.987 0 0 0 .641.541l9.395 7.737Z" />
+        <path d="M11.241 9.817c-.36.275-.801.425-1.255.427-.428 0-.845-.138-1.187-.395L0 2.6V14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2.5l-8.759 7.317Z" />
+    </svg>;
+
+const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type }) => {
+    let color = typeToColor[type];
+    let playedWeekIndicator;
+
+    // Set chip shadow based on whether it is played or not
+    let classShadow: string;
+
+    // Set hover effect based on whether it is played or not
+    let classHover: string;
+
+    // If chip is not played, then use default text:
+    if (gwPlayed === undefined || gwPlayed == null || gwPlayed == "") {
+        gwPlayed = "-"
+
+        classShadow = " shadow-lg shadow-" + color + "-500/50 ";
+        classHover = " hover:bg-" + color + "-800 focus:ring-4 focus:outline-none focus:ring-" + color + "-300 dark:hover:bg-" + color + "-700 dark:focus:ring-" + color + "-800 ";
+        playedWeekIndicator = <div className={"relative shadow-lg shadow-" + color + "-500/50 inline-block text-end p-1 " + (gwPlayed == "-" ? "pr-3" : "pr-2") + " align-middle w-11 h-7 text-xs font-bold text-white bg-blue-800 hover:bg-blue-900 border-2 border-white rounded-br-full rounded-tr-full right-3 z-1 dark:border-gray-900"}>{gwPlayed} </div>;
+    } else {
+        // If chip is used, set the GW label in a gray-tone
+        color = "stone";
+        classShadow = "";
+        classHover = " grayscale-[80%]";
+        playedWeekIndicator = <div className={"relative inline-block text-end p-1 " + (gwPlayed == "-" ? "pr-3" : "pr-2") + " align-middle w-11 h-7 text-xs font-bold text-gray bg-" + color + "-800 hover:bg-" + color + "-900 border-2 border-white rounded-br-full rounded-tr-full right-3 z-1 dark:border-gray-900"}>{gwPlayed} </div>;
+    }
+    let powerUpIcon;
+    if (type == "3xc") {
+        powerUpIcon = "🥊";
+    } else if (type == "wildcard") {
+        powerUpIcon = "🍌";
+    } else if (type == "freehit") {
+        powerUpIcon = "🐢";
+    } else if (type == "bboost") {
+        powerUpIcon = "🍄";
+    }
+
+    /* By including all dynamically used colors in a comment, Tailwind will pull the styling for that class. See: https://stackoverflow.com/a/74959709
+    bg-blue-800 hover:bg-blue-900 dark:border-gray-900
+    shadow-yellow-500/50 text-white bg-yellow-700 hover:bg-yellow-800 focus:ring-yellow-300 dark:bg-yellow-600 dark:hover:bg-yellow-700 dark:focus:ring-yellow-800
+    shadow-red-500/50 text-white bg-red-700 hover:bg-red-800 focus:ring-red-300 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800
+    shadow-green-500/50 text-white bg-green-700 hover:bg-green-800 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800
+    shadow-purple-500/50 text-white bg-purple-700 hover:bg-purple-800 focus:ring-purple-300 dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-800
+    shadow-stone-500/50 text-white bg-stone-700 hover:bg-stone-800 focus:ring-stone-300 dark:bg-stone-600 dark:hover:bg-stone-700 dark:focus:ring-stone-800
+    */
+
+    const [hover, setHover] = useState(false);
+
+    return (
+        <div>
+            <div className="items-center justify-center align-middle" >
+                <button type="button" className={classShadow + " relative z-10 inline-flex p-2 text-sm font-medium text-center text-white bg-" + color + "-700 rounded-full " + classHover + " dark:bg-" + color + "-600 dark:border-" + color + "-900"}>
+                    {powerUpIcon}
+                </button>
+                {playedWeekIndicator}
+            </div>
+        </div >
+    )
+};
+
+export default PowerUp;

--- a/milabowl-astro/src/components/core/PowerUp.tsx
+++ b/milabowl-astro/src/components/core/PowerUp.tsx
@@ -1,9 +1,11 @@
 import iconBomb from "./../../assets/icon_bomb.svg";
+import PowerUpModal from "./PowerUpModal"
 import React, { useState } from "react";
 
 export interface PowerUpProps {
     type: string;  // One of 3xc, wildcard, freehit, bboost
     gwPlayed?: string | null; // Make this nullable?
+    playerName: string; // To know which user card to create modal on
 }
 
 interface iTypeToColor {
@@ -16,6 +18,45 @@ const typeToColor: iTypeToColor = {
     "freehit": "green",
     "bboost": "red"
 };
+interface PowerUpInfo {
+    color: string;
+    icon: string;
+    name: string;
+    explanation: string;
+};
+
+interface TypeDetails {
+    [key: string]: PowerUpInfo;
+};
+
+const num_points = "3";
+
+const powerUpDetails: TypeDetails = {
+    "3xc": {
+        "color": "purple",
+        "icon": "🥊",
+        "name": "Red Shell",
+        "explanation": "-" + num_points + " to the playah' in front of you (in MilaPts) overall. If you're in the lead, targets 2nd place",
+    },
+    "wildcard": {
+        "color": "yellow",
+        "icon": "🍌",
+        "name": "Banana",
+        "explanation": "-" + num_points + " to the playah behind you (in MilaPts) overall",
+    },
+    "freehit": {
+        "color": "green",
+        "icon": "🐢",
+        "name": "Green Shell",
+        "explanation": "-" + num_points + " to the playah' in front of you (in MilaPts) this GW. If you're in the lead, targets 2nd place",
+    },
+    "bboost": {
+        "color": "red",
+        "icon": "🍄",
+        "name": "Mushroom",
+        "explanation": "+50% MilaPts this GW, excluding effects from 💣 and other power ups",
+    }
+};
 
 const icon_envelope =
     <svg className="relative w-3 h-3 z-10" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 16">
@@ -23,8 +64,10 @@ const icon_envelope =
         <path d="M11.241 9.817c-.36.275-.801.425-1.255.427-.428 0-.845-.138-1.187-.395L0 2.6V14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2.5l-8.759 7.317Z" />
     </svg>;
 
-const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type }) => {
-    let color = typeToColor[type];
+const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type, playerName }) => {
+    const powerUp: PowerUpInfo = powerUpDetails[type];
+    //let color = typeToColor[type];
+    let color = powerUp.color;
     let playedWeekIndicator;
 
     // Set chip shadow based on whether it is played or not
@@ -48,15 +91,7 @@ const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type }) => {
         playedWeekIndicator = <div className={"relative inline-block text-end p-1 " + (gwPlayed == "-" ? "pr-3" : "pr-2") + " align-middle w-11 h-7 text-xs font-bold text-gray bg-" + color + "-800 hover:bg-" + color + "-900 border-2 border-white rounded-br-full rounded-tr-full right-3 z-1 dark:border-gray-900"}>{gwPlayed} </div>;
     }
     let powerUpIcon;
-    if (type == "3xc") {
-        powerUpIcon = "🥊";
-    } else if (type == "wildcard") {
-        powerUpIcon = "🍌";
-    } else if (type == "freehit") {
-        powerUpIcon = "🐢";
-    } else if (type == "bboost") {
-        powerUpIcon = "🍄";
-    }
+    powerUpIcon = powerUp.icon;
 
     /* By including all dynamically used colors in a comment, Tailwind will pull the styling for that class. See: https://stackoverflow.com/a/74959709
     bg-blue-800 hover:bg-blue-900 dark:border-gray-900
@@ -69,14 +104,17 @@ const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type }) => {
 
     const [hover, setHover] = useState(false);
 
+    const modal_id = "popup-modal-" + type + playerName;
+
     return (
         <div>
             <div className="items-center justify-center align-middle" >
-                <button type="button" className={classShadow + " relative z-10 inline-flex p-2 text-sm font-medium text-center text-white bg-" + color + "-700 rounded-full " + classHover + " dark:bg-" + color + "-600 dark:border-" + color + "-900"}>
+                <button type="button" data-modal-target={modal_id} data-modal-toggle={modal_id} className={classShadow + " relative z-10 inline-flex p-2 text-sm font-medium text-center text-white bg-" + color + "-700 rounded-full " + classHover + " dark:bg-" + color + "-600 dark:border-" + color + "-900"}>
                     {powerUpIcon}
                 </button>
                 {playedWeekIndicator}
             </div>
+            <PowerUpModal modal_id={modal_id} icon={powerUp.icon} info={powerUp.explanation} name={powerUp.name} />
         </div >
     )
 };

--- a/milabowl-astro/src/components/core/PowerUp.tsx
+++ b/milabowl-astro/src/components/core/PowerUp.tsx
@@ -44,7 +44,7 @@ const PowerUp: React.FC<PowerUpProps> = ({ gwPlayed, type }) => {
         // If chip is used, set the GW label in a gray-tone
         color = "stone";
         classShadow = "";
-        classHover = " grayscale-[80%]";
+        classHover = " grayscale-[60%]";
         playedWeekIndicator = <div className={"relative inline-block text-end p-1 " + (gwPlayed == "-" ? "pr-3" : "pr-2") + " align-middle w-11 h-7 text-xs font-bold text-gray bg-" + color + "-800 hover:bg-" + color + "-900 border-2 border-white rounded-br-full rounded-tr-full right-3 z-1 dark:border-gray-900"}>{gwPlayed} </div>;
     }
     let powerUpIcon;

--- a/milabowl-astro/src/components/core/PowerUpModal.tsx
+++ b/milabowl-astro/src/components/core/PowerUpModal.tsx
@@ -16,7 +16,7 @@ const PowerUpModal: React.FC<PowerUpModalProps> = ({ modal_id, name, icon, info 
 
     return (
         <div>
-            <div id={modal_id} className="fixed top-0 left-0 right-0 z-50 hidden p-4 overflow-x-auto overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+            <div id={modal_id} className="fixed top-0 left-0 right-0 z-50 hidden p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
                 <div className="relative w-full max-w-md max-h-full">
                     <div className="relative bg-white rounded-lg shadow dark:bg-gray-700">
                         <button type="button" className="absolute top-3 right-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white" data-modal-hide={modal_id}>

--- a/milabowl-astro/src/components/core/PowerUpModal.tsx
+++ b/milabowl-astro/src/components/core/PowerUpModal.tsx
@@ -1,0 +1,50 @@
+export interface PowerUpModalProps {
+    modal_id: string;  // THe ID of the modal to link button and modal
+    name: string;  // The header name to display for this modal
+    icon: string;  // The icon to display
+    info: string;  // The information to display
+}
+
+/*
+let icon = <svg className="mx-auto mb-4 text-gray-400 w-12 h-12 dark:text-gray-200" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                                <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 11V6m0 8h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                            </svg>
+*/
+
+
+const PowerUpModal: React.FC<PowerUpModalProps> = ({ modal_id, name, icon, info }) => {
+
+    return (
+        <div>
+            <div id={modal_id} className="fixed top-0 left-0 right-0 z-50 hidden p-4 overflow-x-auto overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div className="relative w-full max-w-md max-h-full">
+                    <div className="relative bg-white rounded-lg shadow dark:bg-gray-700">
+                        <button type="button" className="absolute top-3 right-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ml-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white" data-modal-hide={modal_id}>
+                            <svg className="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                                <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+                            </svg>
+                            <span className="sr-only">Close modal</span>
+                        </button>
+                        <div className="p-6 text-center">
+                            <h3 className="text-lg font-normal text-white ">{icon + "  " + name}</h3>
+                            <div className="mb-5 font-normal text-gray-500 dark:text-gray-400">{info}</div>
+                            <button data-modal-hide={modal_id} type="button"
+                                className="text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300
+                                    dark:focus:ring-red-800 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center mr-2">
+                                Say what??
+                            </button>
+                            <button data-modal-hide={modal_id} type="button"
+                                className="text-white bg-green-600 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300
+                                rounded-lg text-sm font-medium px-5 py-2.5 hover:text-green-900 focus:z-10 dark:bg-green-700
+                                dark:hover:text-white dark:hover:bg-green-800 dark:focus:ring-green-800">
+                                Gotcha'!
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div >
+    )
+};
+
+export default PowerUpModal;


### PR DESCRIPTION
Add power ups to every avatar profile popup.
Shows if they are unused or which GW they were played in.

By clicking on a power up, an explanation will show.
Text is currently overflowing and must be wrapped better in the parent shape.