### PR TITLE
bugfix of typo from -5 pts to -3pts for bomb state dashboard

### DIFF
--- a/milabowl-astro/src/pages/index.astro
+++ b/milabowl-astro/src/pages/index.astro
@@ -107,7 +107,7 @@ const images : ImageMetadata[] = await Astro.glob("../assets/*").then(files => {
 
                           GW {r.gameWeek} - {bombHander && `${bombHander?.teamName.substring(0, 14)}${((bombHander?.teamName?.length ?? 0) >= 14 ? '...' : '')} 👋 =>`}
                           {bombHolder?.milaPoints.bombState !== "Exploded" && '💣'}
-                          {bombHolder?.milaPoints.bombState === "Exploded" && '💥 (- 5 pts) '}
+                          {bombHolder?.milaPoints.bombState === "Exploded" && '💥 (-3 pts) '}
                           {`${bombHolder?.teamName.substring(0, 14)}${((bombHolder?.teamName?.length ?? 0) >= 14 ? '...' : '')}`} 
                         </div>
                       )


### PR DESCRIPTION
According to Milabowl Rules and backend implementation bomb explosion deducts 3 points.

AS-IS: Bomb state on landing page / dashboard explains "- 5 pts".
TO-BE: Bomb state on landing page / dashboard explains "-3 pts".